### PR TITLE
fix(splashview): changed splash to plain white

### DIFF
--- a/SwiftAcademy/App/SplashView.swift
+++ b/SwiftAcademy/App/SplashView.swift
@@ -2,27 +2,7 @@ import SwiftUI
 
 struct SplashView: View {
     var body: some View {
-        ZStack {
-            Color(.systemBackground).ignoresSafeArea()
-
-            VStack {
-                Spacer()
-
-                Image("Logo")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 393, height: 393)
-                    .padding(.bottom, -76.15)
-
-                Text("Swift Academy")
-                    .font(.custom("AmericanTypewriter-Bold", size: 40))
-                    .foregroundColor(Color(hex: "#38b6ff"))
-                    .padding(.bottom, 66)
-
-                Spacer()
-                Spacer()
-            }
-        }
+        Color(.systemBackground).ignoresSafeArea()
     }
 }
 


### PR DESCRIPTION
# Summar
- Changed splash to plain white to look good with diff phone sizes
- Last splash did not match launch screen on certain phone sizes (would be off by a little, looked bad)